### PR TITLE
add: option to allow headings under certain node type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,13 @@ var contents = require('./contents')
 function toc(node, options) {
   var settings = options || {}
   var heading = settings.heading ? toExpression(settings.heading) : null
-  var result = search(node, heading, settings.maxDepth || 6)
+  var parentTypeWhiteList = settings.parents || []
+  var result = search(
+    node,
+    heading,
+    settings.maxDepth || 6,
+    parentTypeWhiteList
+  )
   var map = result.map
 
   result.map = map.length === 0 ? null : contents(map, settings.tight)

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,13 +9,7 @@ var contents = require('./contents')
 function toc(node, options) {
   var settings = options || {}
   var heading = settings.heading ? toExpression(settings.heading) : null
-  var parentTypeWhiteList = settings.parents || []
-  var result = search(
-    node,
-    heading,
-    settings.maxDepth || 6,
-    parentTypeWhiteList
-  )
+  var result = search(node, heading, settings)
   var map = result.map
 
   result.map = map.length === 0 ? null : contents(map, settings.tight)

--- a/lib/search.js
+++ b/lib/search.js
@@ -9,10 +9,12 @@ var slugs = require('github-slugger')()
 var HEADING = 'heading'
 
 // Search a node for a location.
-function search(root, expression, maxDepth, parentTypeWhiteList) {
+function search(root, expression, settings) {
   var length = root.children.length
   var depth = null
   var lookingForToc = expression !== null
+  var maxDepth = settings.maxDepth || 6
+  var parentTypeWhiteList = settings.parents || []
   var map = []
   var headingIndex
   var closingIndex

--- a/lib/search.js
+++ b/lib/search.js
@@ -4,6 +4,7 @@ module.exports = search
 
 var toString = require('mdast-util-to-string')
 var visit = require('unist-util-visit')
+var is = require('unist-util-is')
 var slugs = require('github-slugger')()
 
 var HEADING = 'heading'
@@ -14,7 +15,7 @@ function search(root, expression, settings) {
   var depth = null
   var lookingForToc = expression !== null
   var maxDepth = settings.maxDepth || 6
-  var parentTypeWhiteList = settings.parents || []
+  var parents = settings.parents || []
   var map = []
   var headingIndex
   var closingIndex
@@ -45,7 +46,7 @@ function search(root, expression, settings) {
     var value = toString(child)
     var id = child.data && child.data.hProperties && child.data.hProperties.id
 
-    if (parent !== root && parentTypeWhiteList.indexOf(parent.type) < 0) {
+    if (parent !== root && !is(parents, parent)) {
       return
     }
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -15,8 +15,7 @@ function search(root, expression, settings) {
   var depth = null
   var lookingForToc = expression !== null
   var maxDepth = settings.maxDepth || 6
-  var parents =
-    typeof settings.parents === 'undefined' ? 'root' : settings.parents
+  var parents = settings.parents || root
   var map = []
   var headingIndex
   var closingIndex

--- a/lib/search.js
+++ b/lib/search.js
@@ -15,7 +15,8 @@ function search(root, expression, settings) {
   var depth = null
   var lookingForToc = expression !== null
   var maxDepth = settings.maxDepth || 6
-  var parents = settings.parents || []
+  var parents =
+    typeof settings.parents === 'undefined' ? 'root' : settings.parents
   var map = []
   var headingIndex
   var closingIndex
@@ -46,7 +47,7 @@ function search(root, expression, settings) {
     var value = toString(child)
     var id = child.data && child.data.hProperties && child.data.hProperties.id
 
-    if (parent !== root && !is(parents, parent)) {
+    if (!is(parents, parent)) {
       return
     }
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -9,7 +9,7 @@ var slugs = require('github-slugger')()
 var HEADING = 'heading'
 
 // Search a node for a location.
-function search(root, expression, maxDepth) {
+function search(root, expression, maxDepth, parentTypeWhiteList) {
   var length = root.children.length
   var depth = null
   var lookingForToc = expression !== null
@@ -43,7 +43,7 @@ function search(root, expression, maxDepth) {
     var value = toString(child)
     var id = child.data && child.data.hProperties && child.data.hProperties.id
 
-    if (parent !== root) {
+    if (parent !== root && parentTypeWhiteList.indexOf(parent.type) < 0) {
       return
     }
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "github-slugger": "^1.1.1",
     "mdast-util-to-string": "^1.0.2",
+    "unist-util-is": "^2.1.2",
     "unist-util-visit": "^1.1.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,14 @@ Whether to compile list-items tightly (`boolean?`, default: `false`).
 ###### `options.parents`
 
 Allows headings to be children of certain node types.
-(`string[]`, default: `[]`, i.e. only top-level headings are used)
+Internally, it uses
+[unist-util-is](https://github.com/syntax-tree/unist-util-is) to check.
+Hence all types that can be passed in as first parameter can be used here,
+including `Function`, `string`, `Object` and `Array.<Test>`.
+Check
+[documentation](https://github.com/syntax-tree/unist-util-is#readme)
+for details.
+(default: `[]`, i.e. only top-level headings are used)
 
 Example:
 

--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ including `Function`, `string`, `Object` and `Array.<Test>`.
 Check
 [documentation](https://github.com/syntax-tree/unist-util-is#readme)
 for details.
-(default: `"root"`, which only allows top-level headings)
+(default: the first parameter `node`, which only allows top-level headings)
 
 Example:
 
@@ -100,7 +100,7 @@ Example:
 }
 ```
 
-This would allow headings both on top-level and under `blockquote` to be used.
+This would allow headings under either `root` or `blockquote` to be used.
 
 ##### Returns
 

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,7 @@ If no `heading` is specified, creates a table of contents for all headings in
 
 Links to headings are based on GitHub’s style.
 Only top-level headings (those not in blockquotes or lists), are used.
+(Change this default behavior by using option `parents` as described below)
 The given node is not modified.
 
 ##### `options`
@@ -78,6 +79,21 @@ This is inclusive, thus, when set to `3`, level three headings, are included
 ###### `options.tight`
 
 Whether to compile list-items tightly (`boolean?`, default: `false`).
+
+###### `options.parents`
+
+Allows headings to be children of certain node types.
+(`string[]`, default: `[]`, i.e. only top-level headings are used)
+
+Example:
+
+```json
+{
+  "parents": ["section"]
+}
+```
+
+This would allow headings both on top-level and under `section` node to be used.
 
 ##### Returns
 

--- a/readme.md
+++ b/readme.md
@@ -90,13 +90,13 @@ including `Function`, `string`, `Object` and `Array.<Test>`.
 Check
 [documentation](https://github.com/syntax-tree/unist-util-is#readme)
 for details.
-(default: `[]`, i.e. only top-level headings are used)
+(default: `"root"`, which only allows top-level headings)
 
 Example:
 
 ```json
 {
-  "parents": ["blockquote"]
+  "parents": ["root", "blockquote"]
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -96,11 +96,11 @@ Example:
 
 ```json
 {
-  "parents": ["section"]
+  "parents": ["blockquote"]
 }
 ```
 
-This would allow headings both on top-level and under `section` node to be used.
+This would allow headings both on top-level and under `blockquote` to be used.
 
 ##### Returns
 

--- a/test/fixtures/deep-headings-with-config/config.json
+++ b/test/fixtures/deep-headings-with-config/config.json
@@ -1,3 +1,3 @@
 {
-  "parents": ["blockquote"]
+  "parents": ["root", "blockquote"]
 }

--- a/test/fixtures/deep-headings-with-config/config.json
+++ b/test/fixtures/deep-headings-with-config/config.json
@@ -1,0 +1,3 @@
+{
+  "parents": ["blockquote"]
+}

--- a/test/fixtures/deep-headings-with-config/input.md
+++ b/test/fixtures/deep-headings-with-config/input.md
@@ -1,0 +1,11 @@
+# Something if
+
+## Something else
+
+Text.
+
+> ## heading in a blockquote
+
+* ## heading in a list
+
+# Something iffi

--- a/test/fixtures/deep-headings-with-config/output.json
+++ b/test/fixtures/deep-headings-with-config/output.json
@@ -1,0 +1,110 @@
+{
+  "index": null,
+  "endIndex": null,
+  "map": {
+    "type": "list",
+    "ordered": false,
+    "spread": true,
+    "children": [
+      {
+        "type": "listItem",
+        "loose": true,
+        "spread": true,
+        "children": [
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "link",
+                "title": null,
+                "url": "#something-if",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "Something if"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "list",
+            "ordered": false,
+            "spread": false,
+            "children": [
+              {
+                "type": "listItem",
+                "loose": false,
+                "spread": false,
+                "children": [
+                  {
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "link",
+                        "title": null,
+                        "url": "#something-else",
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "Something else"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "listItem",
+                "loose": false,
+                "spread": false,
+                "children": [
+                  {
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "link",
+                        "title": null,
+                        "url": "#heading-in-a-blockquote",
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "heading in a blockquote"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "listItem",
+        "loose": false,
+        "spread": false,
+        "children": [
+          {
+            "type": "paragraph",
+            "children": [
+              {
+                "type": "link",
+                "title": null,
+                "url": "#something-iffi",
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "Something iffi"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Hi, I would like to propose this extra option to allow more flexibility of toc generation behavior.

My use case is, when I use [remark plugin](https://github.com/jake-low/remark-sectionize) to wrap each section of article into a `section` node, headings are no longer on top level, but I would like to still have these headings inside toc.

This change won't break any existing usage.