### PR TITLE
Add tests for custom node types

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,0 +1,15 @@
+// Dependencies:
+var util = require('util')
+var u = require('unist-builder')
+var toc = require('.')
+
+// Given a mdast tree:
+var tree = u('root', [
+  u('heading', {depth: 1}, [u('text', 'Alpha')]),
+  u('heading', {depth: 2}, [u('text', 'Bravo')]),
+  u('heading', {depth: 3}, [u('text', 'Charlie')]),
+  u('heading', {depth: 2}, [u('text', 'Delta')])
+])
+
+// Yields:
+console.log('javascript', util.inspect(toc(tree), {depth: 3}))

--- a/package.json
+++ b/package.json
@@ -20,22 +20,24 @@
     "index.js"
   ],
   "dependencies": {
-    "github-slugger": "^1.1.1",
-    "mdast-util-to-string": "^1.0.2",
+    "github-slugger": "^1.2.1",
+    "mdast-util-to-string": "^1.0.5",
     "unist-util-is": "^2.1.2",
     "unist-util-visit": "^1.1.0"
   },
   "devDependencies": {
-    "browserify": "^16.2.1",
+    "browserify": "^16.2.3",
     "nyc": "^13.1.0",
     "prettier": "^1.15.2",
     "remark": "^10.0.0",
     "remark-attr": "^0.8.0",
     "remark-cli": "^6.0.0",
     "remark-preset-wooorm": "^4.0.0",
-    "tape": "^4.6.0",
+    "remark-usage": "^6.1.3",
+    "tape": "^4.10.1",
     "tinyify": "^2.5.0",
-    "xo": "^0.23.0"
+    "unist-builder": "^1.0.3",
+    "xo": "^0.24.0"
   },
   "scripts": {
     "format": "remark . -qfo && prettier --write '**/*.js' && xo --fix",
@@ -73,7 +75,8 @@
   },
   "remarkConfig": {
     "plugins": [
-      "preset-wooorm"
+      "preset-wooorm",
+      "remark-usage"
     ]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -19,31 +19,37 @@ npm install mdast-util-toc
 
 ## Usage
 
+Dependencies:
+
 ```javascript
+var util = require('util')
 var u = require('unist-builder')
 var toc = require('mdast-util-toc')
+```
 
+Given a mdast tree:
+
+```javascript
 var tree = u('root', [
   u('heading', {depth: 1}, [u('text', 'Alpha')]),
   u('heading', {depth: 2}, [u('text', 'Bravo')]),
   u('heading', {depth: 3}, [u('text', 'Charlie')]),
   u('heading', {depth: 2}, [u('text', 'Delta')])
 ])
-
-console.log(toc(tree))
 ```
 
 Yields:
 
-```js
+```javascript
+
 { index: null,
   endIndex: null,
-  map:
+  map: 
    { type: 'list',
      ordered: false,
      spread: true,
-     children:
-      [ { type: 'listItem', spread: true, children: [Array] } ] } }
+     children: 
+      [ { type: 'listItem', loose: true, spread: true, children: [Array] } ] } }
 ```
 
 ## API


### PR DESCRIPTION
Adds test coverage for the examples discussed in #53, specifically when passing nodes that are not `type: "root"` directly to `toc()`