### PR TITLE
Feat/support html node WIP

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -6,6 +6,8 @@ var toString = require('mdast-util-to-string')
 var visit = require('unist-util-visit')
 var is = require('unist-util-is')
 var slugs = require('github-slugger')()
+var hastToString = require('hast-util-to-string')
+var rehype = require('rehype')
 
 var HEADING = 'heading'
 
@@ -43,6 +45,11 @@ function search(root, expression, settings) {
   return {index: headingIndex, endIndex: closingIndex, map: map}
 
   function onheading(child, index, parent) {
+    visit(child, 'html', function(node) {
+      node.type = 'text'
+      node.value = hastToString(rehype.parse(node.value))
+    })
+
     var value = toString(child)
     var id = child.data && child.data.hProperties && child.data.hProperties.id
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   ],
   "dependencies": {
     "github-slugger": "^1.2.1",
+    "hast-util-to-string": "^1.0.1",
     "mdast-util-to-string": "^1.0.5",
+    "rehype": "^7.0.0",
     "unist-util-is": "^2.1.2",
     "unist-util-visit": "^1.1.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -115,3 +115,67 @@ test('processing nodes', function(t) {
 
   t.end()
 })
+
+test('processing html node', function(t) {
+  var htmlNode = u('root', [
+    u('heading', {depth: 1}, [
+      u('text', {value: 'Hello '}),
+      u('html', {value: '<code>World</code>'})
+    ])
+  ])
+
+  var htmlNestedNode = u('root', [
+    u('heading', {depth: 1}, [
+      u('text', {value: 'Hello '}),
+      u('paragraph', [u('html', {value: '<div>World</div>'})])
+    ])
+  ])
+
+  const expectedHtmlMap = {
+    type: 'list',
+    ordered: false,
+    spread: false,
+    children: [
+      {
+        type: 'listItem',
+        loose: false,
+        spread: false,
+        children: [
+          {
+            type: 'paragraph',
+            children: [
+              {
+                type: 'link',
+                title: null,
+                url: '#hello-world',
+                children: [{type: 'text', value: 'Hello World'}]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+
+  t.deepEqual(
+    toc(htmlNode),
+    {
+      index: null,
+      endIndex: null,
+      map: expectedHtmlMap
+    },
+    'can process html nodes'
+  )
+
+  t.deepEqual(
+    toc(htmlNestedNode),
+    {
+      index: null,
+      endIndex: null,
+      map: expectedHtmlMap
+    },
+    'can process nested html nodes'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
Hello! This is an attempt at supporting html node mentioned in #56.

I added `rehype` & `hast-util-to-string` to turn this tree
```javascript
u('root', [
    u('heading', {depth: 1}, [
      u('text', {value: 'Hello '}),
      u('html', {value: '<code>World</code>'})
    ])
  ])
```
into this:
```
...
{
  type: 'paragraph',
  children: [{
    type: 'link',
    title: null,
    url: '#hello-world',  // before: '#hello-codeworldcode'
    children: [{ 
      type: 'text', 
      value: 'Hello World'  // before: 'Hello <code>World<code>'
    }] // before: ''
  }]
}
...
```

It'd be great if we could actually get back the inline html in table of contents, such as...
```
  children: [{ 
      type: 'text', 
      value: 'Hello ' 
    }, {
      type: 'html',
      value: '<code>World<code>',
    }]
```
... but I couldn't figure out a simple way to achieve this. Also, after looking at the tests I think this is not consistent with other use case (`mdast-util-to-string` flatten any sort of emphasis or link nodes). I also wonder if bringing in `rehype` is overkill for this.

I'd appreciate any thoughts on this & whether it should be supported, thank you!