### PR TITLE
Fix bug with duplicate headings inside and outside the TOC tree

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -47,6 +47,7 @@ function search(root, expression, settings) {
   function onheading(child, index, parent) {
     var value = toString(child)
     var id = child.data && child.data.hProperties && child.data.hProperties.id
+    var slug = slugs.slug(id || value)
 
     if (!parents(parent)) {
       return
@@ -73,7 +74,7 @@ function search(root, expression, settings) {
       map.push({
         depth: child.depth,
         children: child.children,
-        id: slugs.slug(id || value)
+        id: slug
       })
     }
   }

--- a/test/fixtures/custom-heading/input.md
+++ b/test/fixtures/custom-heading/input.md
@@ -10,4 +10,6 @@ Text.
 
 ## Something elsefi
 
+## Normal
+
 # Something iffi

--- a/test/fixtures/custom-heading/output.json
+++ b/test/fixtures/custom-heading/output.json
@@ -74,6 +74,28 @@
                     ]
                   }
                 ]
+              },
+              {
+                "type": "listItem",
+                "spread": false,
+                "children": [
+                  {
+                    "type": "paragraph",
+                    "children": [
+                      {
+                        "type": "link",
+                        "title": null,
+                        "url": "#normal-1",
+                        "children": [
+                          {
+                            "type": "text",
+                            "value": "Normal"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }


### PR DESCRIPTION
Register the slug of every heading, even if it is before the TOC.
That way, if a heading within the TOC's tree is a duplicate of
one outside the TOC tree, the TOC's slug links still be accurate.

Closes #63.

<!--

Read the [contributing guidelines](https://github.com/syntax-tree/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/syntax-tree/.github/blob/master/support.md
https://github.com/syntax-tree/.github/blob/master/contributing.md
-->
