### PR TITLE
fixed issue where children cannot work when empty

### DIFF
--- a/lib/contents.js
+++ b/lib/contents.js
@@ -120,7 +120,7 @@ function all(children) {
 function one(node) {
   var copy
 
-  if (node.type === LINK || node.type === LINK_REFERENCE) {
+  if ((node.type === LINK || node.type === LINK_REFERENCE) && node.children) {
     return all(node.children)
   }
 


### PR DESCRIPTION
 When getting tableOfContents in my project, sometimes I get an error: 
`"TypeError: Cannot read property 'length' of undefined",`

this pr can solve the problem